### PR TITLE
Fix binary path for folders different than home

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -30,4 +30,4 @@ chmod +x $BUILD_DIR/vendor/phantomjs/bin/phantomjs
 echo "-----> exporting PATH and LIBRARY_PATH"
 PROFILE_PATH="$BUILD_DIR/.profile.d/phantomjs.sh"
 mkdir -p $(dirname $PROFILE_PATH)
-echo 'export PATH="$PATH:vendor/phantomjs/bin"' >> $PROFILE_PATH
+echo 'export PATH="$PATH:/app/vendor/phantomjs/bin"' >> $PROFILE_PATH


### PR DESCRIPTION
The path is relative and if you try to access phantomjs binary from any other folder than home, it doesn't work.